### PR TITLE
[community] Update the use flags for Flatpak

### DIFF
--- a/community/specs/custom.use
+++ b/community/specs/custom.use
@@ -5,3 +5,5 @@ games-simulation/vegastrike -ffmpeg
 x11-libs/vte vala
 x11-misc/mugshot webcam
 #www-client/w3m fbcon imlib
+sys-apps/flatpak archive
+sys-apps/xdg-desktop-portal-gtk -wayland


### PR DESCRIPTION
Realized I had some use flag changes on my testing machine, stupid of me...

Have to disable wayland on the GTK desktop portal until there's a gtk+ >= 3.21.5 that's been built with Wayland support.
Also enabling archive support on Flatpak, since otherwise it's impossible to build many of the example flatpaks available at the moment.
