### PR TITLE
[community] Add app-editors/atom-bin::jorgicio

### DIFF
--- a/community/build.yaml
+++ b/community/build.yaml
@@ -83,6 +83,7 @@ build:
     - app-arch/rarcrack::robbat2
     - app-crypt/veracrypt
     - app-dicts/artha
+    - app-editors/atom-bin::jorgicio
     - app-editors/gedit-latex::eva
     - app-editors/scribes::belak
     - app-editors/sublime-text::sublime-text


### PR DESCRIPTION
Alternative to gentoo's compiled version, which has broken
functionality in certain places.