### PR TITLE
community/build.yaml: Add bgo-overlay to overlay list

### DIFF
--- a/community/build.yaml
+++ b/community/build.yaml
@@ -21,6 +21,7 @@ build:
     - belak
     - bobwya
     - brother-overlay
+    - bgo-overlay
     - c2p-overlay
     - cynede
     - Drauthius


### PR DESCRIPTION
Add so that app-dicts/artha which is already in build.yaml will
pull from there and build.