### PR TITLE
[community] Add dev-util/flatpak-builder

### DIFF
--- a/community/build.yaml
+++ b/community/build.yaml
@@ -112,6 +112,7 @@ build:
     - dev-tex/mimetex::k_f
     - dev-util/adobe-air-runtime::steam-overlay
     - dev-util/eclipse-sdk-bin::jorgicio
+    - dev-util/flatpak-builder::flatpak-overlay
     - dev-util/idea-community::ssnb
     - dev-util/phpstorm
     - dev-util/pycharm-community


### PR DESCRIPTION
The builder part was split from Flatpak itself as of 0.9.9