### PR TITLE
[community] Add app-misc/anki::sk-overlay

### DIFF
--- a/community/build.yaml
+++ b/community/build.yaml
@@ -93,6 +93,7 @@ build:
     - app-eselect/eselect-sublime::sublime-text
     - app-i18n/virtaal::LocalOverlay
     - app-laptop/tlp
+    - app-misc/anki::sk-overlay
     - app-misc/double-commander
     - app-misc/fet::LocalOverlay
     - app-misc/gramps::genealogy


### PR DESCRIPTION
Just added the anki 2.1 build but with a patch to allow it to run on
Python 3.5 instead of requiring Python 3.6. Gentoo's anki was masked due
to it relying on qtwebkit 4, and cannot be installed from
sabayonlinux.org anymore.