### PR TITLE
[community] Rename sys-fs/ostree

### DIFF
--- a/community/build.yaml
+++ b/community/build.yaml
@@ -172,7 +172,7 @@ build:
     - sys-app/xdg-desktop-portal-gtk
     - sys-cluster/kubectl
     - sys-cluster/minikube
-    - sys-fs/ostree
+    - sys-fs/libostree
     - sys-fs/zfstools::graaff
     - www-apps/hugo::go-overlay
     - www-client/palemoon-bin::palemoon


### PR DESCRIPTION
The new name of `sys-fs/libostree` is so far only used by the flatpak-overlay packages, but they are also the only ebuilds I can find that depend on ostree in the first place, so switching to the new name probably makes sense in order to keep them working.

Gentoo proper will also adopt the new name as time permits, but for now flatpak and flatpak-builder explicitly require the new name.