### PR TITLE
[community] Take flatpak from flatpak-overlay

### DIFF
--- a/community/build.yaml
+++ b/community/build.yaml
@@ -147,7 +147,7 @@ build:
     - net-print/brother-genml1-bin::brother-overlay
     - net-print/samsung-unified-driver
     - sci-geosciences/googleearth::mv
-    - sys-apps/flatpak
+    - sys-apps/flatpak::flatpak-overlay
     - sys-apps/hw-probe
     - sys-apps/sift::go-overlay
     - sys-apps/xdg-desktop-portal::flatpak-overlay


### PR DESCRIPTION
I'm guessing that this is part of the reason why flatpak is still 1.4.0 in the community repo, when 1.4.4 is the oldest ebuild, and 1.8.2 is available too.